### PR TITLE
Add postfix ops syntax example

### DIFF
--- a/src/main/scala/leopards/ApplicativeError.scala
+++ b/src/main/scala/leopards/ApplicativeError.scala
@@ -1,0 +1,6 @@
+package leopards
+
+trait ApplicativeError[F[_], E] extends Applicative[F]:
+  def raiseError[A](e: E): F[A]
+  extension [A](fa: F[A])
+    def handleError(f: Throwable => A): F[A]

--- a/src/main/scala/leopards/Monad.scala
+++ b/src/main/scala/leopards/Monad.scala
@@ -3,3 +3,6 @@ package leopards
 trait Monad[F[_]] extends FlatMap[F], Applicative[F]:
   extension [A](fa: F[A])
     override def map[B](f: A => B): F[B] = fa.flatMap(f andThen pure)
+
+object Monad:
+  def apply[F[_]](using m: Monad[F]) = m

--- a/src/main/scala/leopards/instances/try.scala
+++ b/src/main/scala/leopards/instances/try.scala
@@ -1,0 +1,16 @@
+package leopards
+
+import scala.util.{Try, Failure, Success}
+import scala.util.control.NonFatal
+
+given ApplicativeError[Try, Throwable] with
+  override def pure[A](a: A): Try[A] = Try(a)
+  override  def raiseError[A](e: Throwable): Try[A] = Failure(e)
+  
+  extension [A](fa: Try[A])
+    override def map[B](f: A => B): Try[B] = fa.map(f)
+    override def handleError(f: Throwable => A): Try[A] = fa.recover[A] { case e => f(e) }
+  
+  extension [A, B](ff: Try[A => B])
+    override def <*>(fa: Try[A]): Try[B] =
+      ff.flatMap(f => fa.map(f))

--- a/src/main/scala/leopards/syntax/applicative.scala
+++ b/src/main/scala/leopards/syntax/applicative.scala
@@ -1,0 +1,6 @@
+package leopards.syntax
+
+import leopards.Applicative
+
+extension [A](a: A)
+  def pure[F[_]](using F: Applicative[F]): F[A] = F.pure(a)

--- a/src/main/scala/leopards/syntax/applicativeError.scala
+++ b/src/main/scala/leopards/syntax/applicativeError.scala
@@ -1,0 +1,6 @@
+package leopards.syntax
+
+import leopards.ApplicativeError
+
+extension [E](e: E)
+  def raiseError[F[_], A](using F: ApplicativeError[F, E]): F[A] = F.raiseError[A](e)

--- a/src/test/scala/leopards/testsyntax/SyntaxTest.scala
+++ b/src/test/scala/leopards/testsyntax/SyntaxTest.scala
@@ -1,0 +1,33 @@
+package leopards.testsyntax
+
+import munit.FunSuite
+
+import leopards.{*, given}
+import leopards.syntax.*
+
+class SyntaxExample extends FunSuite:
+
+  test("f poly summon ") {
+    def fPolySummon[F[_]: Monad](value: Int): F[Int] = Monad[F].pure(42)
+    assertEquals(fPolySummon[Option](42), Some(42))
+  }
+
+  test("f poly flatMap") {
+    // for the flatMap we need the leopards.{*, given} import
+    // for the value.pure[F] we need the leopards.syntax.* import
+    def fPolyFlatMap[F[_]: Monad](value: Int): F[Int] = 
+      for {
+        v <- value.pure[F]
+      } yield v
+    
+    assertEquals(fPolyFlatMap[Option](42), Some(42))
+  }
+
+  test("applicative error syntax") {
+    import scala.util.Try
+    val thr = new RuntimeException("stuff")
+    //val tried = thr.raiseError[Try, String] // -- does not compile because thr is inferred as RuntimeException, not Throwable
+    val tried = (thr: Throwable).raiseError[Try, String]
+    assert(tried.isFailure)
+    assertEquals(tried.handleError(_ => "42"), Try("42"))
+  }


### PR DESCRIPTION
I was curious how syntax for stuff like `42.pure[Option]` would look like, and how extension method resolution would work in `F[_]` polymorphic code.

Also added incomplete/barebones `ApplicativeError`, to see how inference works for Throwables in `new RuntimeException("stuff").raiseError[Try, Unit]` syntax.

Moved syntax tests under `leopards.testsyntax`, to force usage of imports. Currently it looks a lot like cats, and seems to work:
```scala
import leopards.{*, given}
import leopards.syntax.*
```
To get all bells and whistles imported.