### PR TITLE
Update to scala 3.4.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ ThisBuild / developers ++= List(
   tlGitHubDev("mpilquist", "Michael Pilquist")
 )
 
-ThisBuild / scalaVersion := "3.3.1"
+ThisBuild / scalaVersion := "3.4.0-RC2"
 
 lazy val root = tlCrossRootProject
   .aggregate(core)
@@ -29,7 +29,7 @@ lazy val root = tlCrossRootProject
 lazy val core = crossProject(JVMPlatform, JSPlatform)
   .settings(
     name := "spotted-leopards",
-    libraryDependencies += "org.scalameta" %%% "munit-scalacheck" % "0.7.29",
+    libraryDependencies += "org.scalameta" %%% "munit-scalacheck" % "1.0.0-M11",
     Compile / console / scalacOptions := (Compile / console / scalacOptions).value
       .filterNot(_.startsWith("-Wunused"))
   )


### PR DESCRIPTION
No longer compiles due to changes in ambiguous extension methods. Related to #9.